### PR TITLE
chore(refactor): refactor the routes

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,14 +1,7 @@
-use crate::{expander, proxy, request, utils::handle_reqwest_error};
-use std::{collections::HashMap, env::args};
-
-use axum::{
-    Router,
-    extract::{Query, State},
-    response::IntoResponse,
-    routing::get,
-};
-use reqwest::{Client, Method, StatusCode};
-use tower_http::cors::{AllowOrigin, CorsLayer};
+pub mod routes;
+use axum::Router;
+use reqwest::Client;
+use std::env::args;
 
 #[derive(Clone)]
 struct AppState {
@@ -21,53 +14,9 @@ pub async fn run() {
     let port = args.get(1).unwrap_or(&default_port);
     let address = format!("127.0.0.1:{port}");
 
-    let client = request::create_reqwest();
-    let state = AppState { client };
-
-    // Layers
-    let cors = CorsLayer::new()
-        .allow_methods([Method::GET])
-        .allow_origin(AllowOrigin::mirror_request());
-
-    let app = Router::new()
-        .route("/", get(index_handler))
-        .route("/proxy", get(proxy_url))
-        .with_state(state)
-        .layer(cors);
+    let app = Router::new().merge(routes::routes());
 
     println!("Server running on http://{}", &address);
     let listener = tokio::net::TcpListener::bind(address).await.unwrap();
     axum::serve(listener, app).await.unwrap();
-}
-
-async fn index_handler(
-    State(state): State<AppState>,
-    Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
-    let client = state.client;
-
-    if let Some(url) = params.get("url") {
-        match expander::expand_url(url.to_string(), client).await {
-            Ok(url) => (StatusCode::OK, url),
-            Err(error) => handle_reqwest_error(error),
-        }
-    } else {
-        (StatusCode::BAD_REQUEST, "URL parameter missing".to_string())
-    }
-}
-
-async fn proxy_url(
-    State(state): State<AppState>,
-    Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
-    let client = state.client;
-
-    if let Some(url) = params.get("url") {
-        match proxy::return_preview_html(url.to_string(), client).await {
-            Ok(html) => (StatusCode::OK, html.to_string()),
-            Err(error) => handle_reqwest_error(error),
-        }
-    } else {
-        (StatusCode::BAD_REQUEST, "URL parameter missing".to_string())
-    }
 }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+
+use axum::{
+    Router,
+    extract::{Query, State},
+    response::IntoResponse,
+    routing::get,
+};
+use reqwest::{Method, StatusCode};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+use crate::{expander, proxy, request, server::AppState, utils::handle_reqwest_error};
+
+pub fn routes() -> Router {
+    Router::new()
+        .nest("/api", api_routes())
+        .merge(index_routes())
+}
+
+fn index_routes() -> Router {
+    let cors = CorsLayer::new()
+        .allow_methods([Method::GET])
+        .allow_origin(AllowOrigin::mirror_request());
+    let client = request::create_reqwest();
+    let state = AppState { client };
+    Router::new()
+        .route("/", get(index_handler))
+        .route("/proxy", get(proxy_url))
+        .with_state(state)
+        .layer(cors)
+}
+
+fn api_routes() -> Router {
+    Router::new().route("/health", get(health_handler))
+}
+
+///
+/// Methods here
+///
+async fn health_handler() -> impl IntoResponse {
+    (StatusCode::OK, "OK".to_string())
+}
+
+async fn index_handler(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let client = state.client;
+
+    if let Some(url) = params.get("url") {
+        match expander::expand_url(url.to_string(), client).await {
+            Ok(url) => (StatusCode::OK, url),
+            Err(error) => handle_reqwest_error(error),
+        }
+    } else {
+        (StatusCode::BAD_REQUEST, "URL parameter missing".to_string())
+    }
+}
+
+async fn proxy_url(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let client = state.client;
+
+    if let Some(url) = params.get("url") {
+        match proxy::return_preview_html(url.to_string(), client).await {
+            Ok(html) => (StatusCode::OK, html.to_string()),
+            Err(error) => handle_reqwest_error(error),
+        }
+    } else {
+        (StatusCode::BAD_REQUEST, "URL parameter missing".to_string())
+    }
+}


### PR DESCRIPTION
This will allow for selective CORs setting. Public routes like `/proxy` will have the CORS allow origin header match the client header but for auth routes, and others that will come in future releases, this will not be the case.